### PR TITLE
[fix] platform channel issue

### DIFF
--- a/ios/Classes/SwiftHyperpayPlugin.swift
+++ b/ios/Classes/SwiftHyperpayPlugin.swift
@@ -93,12 +93,22 @@ public class SwiftHyperpayPlugin: UINavigationController, FlutterPlugin, SFSafar
         let channel = FlutterMethodChannel(name: "plugins.nyartech.com/hyperpay", binaryMessenger: registrar.messenger())
         let instance = SwiftHyperpayPlugin()
         let buttonFactory = ApplePayButtonViewFactory(messenger: registrar.messenger())
+
+        if let delegate = UIApplication.shared.connectedScenes.flatMap { ($0 as? UIWindowScene)?.windows ?? [] }.first { $0.isKeyWindow }  {
+
+            let controller = delegate.window?.rootViewController as? FlutterViewController
+
+            let navigationController = UINavigationController(rootViewController: controller!)
+
+
+            delegate.window?.rootViewController?.view.removeFromSuperview()
+            delegate.window?.rootViewController = navigationController
+
+            navigationController.setNavigationBarHidden(true, animated: false)
         
-        let controller = UIApplication.shared.delegate?.window??.rootViewController as? FlutterViewController
-        let navigationController = UINavigationController(rootViewController: controller!)
-        UIApplication.shared.delegate?.window??.rootViewController = navigationController
-        navigationController.setNavigationBarHidden(true, animated: false)
-        UIApplication.shared.delegate?.window??.makeKeyAndVisible()
+             delegate.window?.makeKeyAndVisible()
+    
+        }
         
         registrar.register(buttonFactory, withId: "plugins.nyartech.com/hyperpay/apple_pay_button")
         registrar.addMethodCallDelegate(instance, channel: channel)

--- a/ios/hyperpay.podspec
+++ b/ios/hyperpay.podspec
@@ -14,7 +14,7 @@ A new flutter plugin project.
   s.author           = { 'Your Company' => 'email@example.com' }
   s.source           = { :path => '.' }
   s.dependency 'Flutter'
-  s.platform = :ios, '8.0'
+  s.platform = :ios, '13.0'
 
   s.source_files     = 'Classes/**/*'
   


### PR DESCRIPTION
## Context
The current implementation of `UINavigationController` in `register` [method](https://github.com/nyartech/hyperpay/blob/main/ios/Classes/SwiftHyperpayPlugin.swift#L92-L106) has some deprecated code, which results in breaking Flutter's platform channel when the plugin is injected into a Flutter application (see #45 )

## Solution
This PR replaces the deprecated code with the appropriate code that does the exact same thing.
For more information about the solution, check [How to resolve: 'keyWindow' was deprecated in iOS 13.0](https://stackoverflow.com/a/58031897/9410194) and [Apple's docs, rootViewController](https://developer.apple.com/documentation/uikit/uiwindow/1621581-rootviewcontroller)

### Notes
This solution needs a target platform of IOS 13 and above. Hence, this PR bumps the target platform from IOS 8 _(previously)_ to IOS 13

closes #45 